### PR TITLE
Fix three code bugs

### DIFF
--- a/packages/inspector/src/inspector.ts
+++ b/packages/inspector/src/inspector.ts
@@ -9,6 +9,7 @@ import {
 } from '@jupyterlab/translation';
 import { Panel, PanelLayout, Widget } from '@lumino/widgets';
 import { IInspector } from './tokens';
+import { Sanitizer } from '@jupyterlab/apputils';
 
 /**
  * The class name added to inspector panels.
@@ -147,7 +148,8 @@ export class InspectorPanel
    */
   private static _generateContentWidget(message: string): Widget {
     const widget = new Widget();
-    widget.node.innerHTML = message;
+    const sanitizer = new Sanitizer();
+    widget.node.innerHTML = sanitizer.sanitize(message);
     widget.addClass(CONTENT_CLASS);
     widget.addClass(DEFAULT_CONTENT_CLASS);
 

--- a/packages/services/src/terminal/manager.ts
+++ b/packages/services/src/terminal/manager.ts
@@ -234,7 +234,7 @@ export class TerminalManager extends BaseManager implements Terminal.IManager {
     }
 
     const names = models.map(({ name }) => name).sort();
-    if (names === this._names) {
+    if (names.length === this._names.length && names.every((n, i) => n === this._names[i])) {
       // Identical models list, so just return
       return;
     }

--- a/packages/ui-components/src/components/table.tsx
+++ b/packages/ui-components/src/components/table.tsx
@@ -77,7 +77,7 @@ export function Table<T>(props: Table.IOptions<T>) {
 
   if (sortedColumn) {
     const sorter = sortedColumn.sort.bind(sortedColumn);
-    rows = props.rows.sort(
+    rows = [...props.rows].sort(
       (a, b) => sorter(a.data, b.data) * sortState.sortDirection
     );
   }


### PR DESCRIPTION
## References

This PR addresses three identified bugs:
*   React table mutates props when sorting.
*   Terminal manager compares arrays by reference.
*   XSS risk in Inspector content.

## Code changes

This PR introduces three targeted bug fixes:
*   **`packages/ui-components/src/components/table.tsx`**: Modified the `Table` component to sort a shallow copy of `props.rows` instead of mutating the original array in place. This prevents unintended side effects and adheres to React best practices for prop immutability.
*   **`packages/services/src/terminal/manager.ts`**: Updated the `TerminalManager` to perform a deep equality check when comparing array `names` (length and element-wise comparison) instead of a reference comparison. This ensures that unnecessary updates are avoided when the content of the arrays is identical.
*   **`packages/inspector/src/inspector.ts`**: Implemented HTML sanitization using `Sanitizer` before assigning content to `innerHTML` in `InspectorPanel`'s `_generateContentWidget` method. This mitigates a potential Cross-Site Scripting (XSS) vulnerability by preventing arbitrary script injection.

## User-facing changes

*   **Table sorting**: No direct visual changes, but improves the stability and predictability of table rendering, preventing potential subtle UI bugs.
*   **Terminal Manager**: No direct user-facing changes; improves internal performance and reduces unnecessary updates.
*   **Inspector Panel**: No visible changes for valid content, but enhances security by preventing malicious script execution from untrusted HTML content.

## Backwards-incompatible changes

None.

---
<a href="https://cursor.com/background-agent?bcId=bc-caa377b6-2ae7-4561-9eea-4cf1ec30414b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-caa377b6-2ae7-4561-9eea-4cf1ec30414b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

